### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -69,5 +69,6 @@
   "tasksRunnerOptions": {
     "default": { "options": { "cacheableOperations": ["build-storybook"] } }
   },
-  "nxCloudAccessToken": "ZDdhZGMyNGUtODEyOC00YzRlLTkzY2QtYjFmZDNjM2U2ZjUwfHJlYWQtd3JpdGU="
+  "nxCloudAccessToken": "MDc0YmVlOTctNWVhMC00MzgyLThjMWUtOGQxYWE5Njg0M2Q0fHJlYWQtd3JpdGU=",
+  "nxCloudUrl": "https://staging.nx.app"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://staging.nx.app/orgs/667606ca35f7871845173437/workspaces/667c45c99aa79e2f4be96d26

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.